### PR TITLE
fix: update debian build rules for sw64 architecture

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+seetaface-tennis (1.0.1-0deepin2) unstable; urgency=medium
+
+  * fix: update debian build rules for sw64 architecture
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Wed, 16 Jul 2025 11:19:23 +0800
+
 seetaface-tennis (1.0.1-0deepin1) unstable; urgency=medium
   
   [ LiChengGang ]

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,5 @@
 #!/usr/bin/make -f
+include /usr/share/dpkg/default.mk
 # See debhelper(7) (uncomment to enable)
 # output every command that modifies files on the build system.
 export DH_VERBOSE = 1
@@ -13,10 +14,16 @@ export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
 
 %:
 	dh $@
 
+ifeq ($(DEB_HOST_ARCH_CPU),sw64)
+override_dh_auto_configure:
+	dh_auto_configure -- -DTS_USE_OPENMP=OFF -DTS_USE_SIMD=OFF
+endif
 
 override_dh_auto_install:
 	dh_auto_install -- prefix=/usr


### PR DESCRIPTION
1. Added inclusion of dpkg default makefile for standard variables
2. Added DEB_HOST_MULTIARCH detection for cross-building support
3. Added special configuration flags for sw64 architecture builds
4. Disabled OpenMP and SIMD optimizations on sw64 due to compatibility
issues

The changes ensure proper package building on sw64 architecture by:
- Including necessary dpkg configuration
- Adding architecture-specific optimizations
- Disabling unsupported features on sw64 platform

fix: 更新 debian 构建规则以支持 sw64 架构

1. 添加 dpkg 默认 makefile 包含以获取标准变量
2. 添加 DEB_HOST_MULTIARCH 检测以支持交叉编译
3. 为 sw64 架构添加特殊配置标志
4. 在 sw64 上禁用 OpenMP 和 SIMD 优化以解决兼容性问题

这些更改确保在 sw64 架构上正确构建软件包：
- 包含必要的 dpkg 配置
- 添加特定架构的优化
- 在 sw64 平台上禁用不支持的功能
